### PR TITLE
fix NPE when a model doesnt have an algorithm

### DIFF
--- a/mmds-app/src/main/java/co/cask/mmds/manager/ModelManagerServiceHandler.java
+++ b/mmds-app/src/main/java/co/cask/mmds/manager/ModelManagerServiceHandler.java
@@ -42,6 +42,7 @@ import co.cask.mmds.data.ModelTable;
 import co.cask.mmds.data.ModelTrainerInfo;
 import co.cask.mmds.data.SplitKey;
 import co.cask.mmds.manager.runner.AlgorithmSpec;
+import co.cask.mmds.manager.runner.EnumStringTypeAdapterFactory;
 import co.cask.mmds.manager.runner.PipelineExecutor;
 import co.cask.mmds.modeler.Modelers;
 import co.cask.mmds.modeler.param.spec.ParamSpec;
@@ -86,6 +87,7 @@ public class ModelManagerServiceHandler implements SparkHttpServiceHandler {
   private static final Logger LOG = LoggerFactory.getLogger(ModelManagerServiceHandler.class);
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
+    .registerTypeAdapterFactory(new EnumStringTypeAdapterFactory())
     .serializeSpecialFloatingPointValues()
     .create();
   private String modelMetaDataset;
@@ -314,7 +316,7 @@ public class ModelManagerServiceHandler implements SparkHttpServiceHandler {
       }
     }).start();
 
-    responder.sendString(GSON.toJson(new Id(trainerInfo.getModelId())));
+    responder.sendStatus(200);
   }
 
   @DELETE

--- a/mmds-app/src/main/java/co/cask/mmds/manager/runner/EnumStringTypeAdapterFactory.java
+++ b/mmds-app/src/main/java/co/cask/mmds/manager/runner/EnumStringTypeAdapterFactory.java
@@ -1,0 +1,49 @@
+package co.cask.mmds.manager.runner;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Serializes/deserializes enums using the value of the toString method instead of the name method.
+ */
+public class EnumStringTypeAdapterFactory implements TypeAdapterFactory {
+  public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+    Class<T> rawType = (Class<T>) type.getRawType();
+    if (!rawType.isEnum()) {
+      return null;
+    }
+
+    final Map<String, T> labelMap = new HashMap<>();
+    for (T constant : rawType.getEnumConstants()) {
+      labelMap.put(constant.toString(), constant);
+    }
+
+    return new TypeAdapter<T>() {
+      public void write(JsonWriter out, T value) throws IOException {
+        if (value == null) {
+          out.nullValue();
+        } else {
+          out.value(value.toString());
+        }
+      }
+
+      public T read(JsonReader reader) throws IOException {
+        if (reader.peek() == JsonToken.NULL) {
+          reader.nextNull();
+          return null;
+        } else {
+          return labelMap.get(reader.nextString());
+        }
+      }
+    };
+  }
+}

--- a/mmds-model/src/main/java/co/cask/mmds/data/ExperimentStore.java
+++ b/mmds-model/src/main/java/co/cask/mmds/data/ExperimentStore.java
@@ -70,7 +70,7 @@ public class ExperimentStore {
     Iterator<ModelMeta> modelIter = models.iterator();
     ModelMeta modelMeta = modelIter.next();
     algoHisto.update(modelMeta.getAlgorithm());
-    statusHisto.update(modelMeta.getStatus() == null ? null : modelMeta.getStatus().name());
+    statusHisto.update(modelMeta.getStatus() == null ? null : modelMeta.getStatus().toString());
 
     EvaluationMetrics metrics = modelMeta.getEvaluationMetrics();
     NumericStats rmse = new NumericStats(metrics.getRmse());

--- a/mmds-model/src/main/java/co/cask/mmds/data/ModelStatus.java
+++ b/mmds-model/src/main/java/co/cask/mmds/data/ModelStatus.java
@@ -1,7 +1,5 @@
 package co.cask.mmds.data;
 
-import com.google.gson.annotations.SerializedName;
-
 /**
  * Model status. The state transition diagram is:
  *
@@ -40,20 +38,22 @@ import com.google.gson.annotations.SerializedName;
  * be assigned a different split, which moves it back to the SPLITTING state.
  */
 public enum ModelStatus {
-  @SerializedName("Empty")
-  EMPTY,
-  @SerializedName("Splitting")
-  SPLITTING,
-  @SerializedName("Split Failed")
-  SPLIT_FAILED,
-  @SerializedName("Data Ready")
-  DATA_READY,
-  @SerializedName("Training")
-  TRAINING,
-  @SerializedName("Trained")
-  TRAINED,
-  @SerializedName("Training Failed")
-  TRAINING_FAILED,
-  @SerializedName("Deployed")
-  DEPLOYED
+  EMPTY("Empty"),
+  SPLITTING("Splitting"),
+  SPLIT_FAILED("Split Failed"),
+  DATA_READY("Data Ready"),
+  TRAINING("Training"),
+  TRAINED("Trained"),
+  TRAINING_FAILED("Training Failed"),
+  DEPLOYED("Deployed");
+  private final String label;
+
+  ModelStatus(String label) {
+    this.label = label;
+  }
+
+  @Override
+  public String toString() {
+    return label;
+  }
 }

--- a/mmds-model/src/main/java/co/cask/mmds/data/SplitStatus.java
+++ b/mmds-model/src/main/java/co/cask/mmds/data/SplitStatus.java
@@ -1,15 +1,20 @@
 package co.cask.mmds.data;
 
-import com.google.gson.annotations.SerializedName;
-
 /**
  * Split states.
  */
 public enum SplitStatus {
-  @SerializedName("Splitting")
-  SPLITTING,
-  @SerializedName("Complete")
-  COMPLETE,
-  @SerializedName("Failed")
-  FAILED
+  SPLITTING("Splitting"),
+  COMPLETE("Complete"),
+  FAILED("Failed");
+  private final String label;
+
+  SplitStatus(String label) {
+    this.label = label;
+  }
+
+  @Override
+  public String toString() {
+    return label;
+  }
 }

--- a/mmds-model/src/main/java/co/cask/mmds/stats/CategoricalHisto.java
+++ b/mmds-model/src/main/java/co/cask/mmds/stats/CategoricalHisto.java
@@ -31,17 +31,19 @@ public class CategoricalHisto extends Histogram<CategoricalHisto> implements Ser
   }
 
   public void update(String val) {
+    totalCount++;
+    if (val == null) {
+      nullCount++;
+      return;
+    } else if (val.isEmpty()) {
+      emptyCount++;
+    }
+
     Long currentVal = counts.get(val);
     if (currentVal == null) {
       counts.put(val, 1L);
     } else {
       counts.put(val, currentVal + 1);
-    }
-    totalCount++;
-    if (val == null) {
-      nullCount++;
-    } else if (val.isEmpty()) {
-      emptyCount++;
     }
   }
 


### PR DESCRIPTION
Fix categorical histograms so that they don't include null as a
histogram bucket. This fixes a bug in the get experiment endpoint,
where a model without an algorithm would cause a null pointer
exception. Also fixes a bug where the status histogram returned
by the endpoint was using different values than the model status
endpoint.