### PR TITLE
Add more stages to the model lifecycle

### DIFF
--- a/mmds-app/src/main/java/co/cask/mmds/manager/Id.java
+++ b/mmds-app/src/main/java/co/cask/mmds/manager/Id.java
@@ -1,5 +1,7 @@
 package co.cask.mmds.manager;
 
+import co.cask.mmds.proto.BadRequestException;
+
 /**
  * Holds an id
  */
@@ -12,5 +14,11 @@ public class Id {
 
   public String getId() {
     return id;
+  }
+
+  public void validate() {
+    if (id == null) {
+      throw new BadRequestException("Id must be specified.");
+    }
   }
 }

--- a/mmds-app/src/main/java/co/cask/mmds/manager/ModelPrepApp.java
+++ b/mmds-app/src/main/java/co/cask/mmds/manager/ModelPrepApp.java
@@ -26,6 +26,7 @@ import co.cask.cdap.api.dataset.table.Table;
 import co.cask.mmds.Constants;
 import co.cask.mmds.data.DataSplitTable;
 import co.cask.mmds.data.ExperimentMetaTable;
+import co.cask.mmds.data.ModelTable;
 import com.google.common.annotations.VisibleForTesting;
 
 /**
@@ -46,7 +47,7 @@ public class ModelPrepApp extends AbstractApplication<ModelPrepApp.Conf> {
     String experimentMetaName = conf.getExperimentMetaDataset();
     String splitsName = conf.getSplitsDataset();
     createDataset(experimentMetaName, IndexedTable.class, ExperimentMetaTable.DATASET_PROPERTIES);
-    createDataset(modelMetaName, Table.class, DatasetProperties.EMPTY);
+    createDataset(modelMetaName, IndexedTable.class, ModelTable.DATASET_PROPERTIES);
     createDataset(modelComponentsName, FileSet.class, DatasetProperties.EMPTY);
     createDataset(splitsName, PartitionedFileSet.class, DataSplitTable.DATASET_PROPERTIES);
 

--- a/mmds-model/src/main/java/co/cask/mmds/data/DataSplit.java
+++ b/mmds-model/src/main/java/co/cask/mmds/data/DataSplit.java
@@ -84,6 +84,9 @@ public class DataSplit {
     if (schema == null) {
       throw new IllegalArgumentException("A schema must be specified.");
     }
+    if (directives == null) {
+      throw new IllegalArgumentException("Directives must be specified.");
+    }
     DatasetSplitter splitter = Splitters.getSplitter(type);
     if (splitter == null) {
       throw new IllegalArgumentException("No splitter of type " + type + " exists.");

--- a/mmds-model/src/main/java/co/cask/mmds/data/Model.java
+++ b/mmds-model/src/main/java/co/cask/mmds/data/Model.java
@@ -16,8 +16,10 @@
 
 package co.cask.mmds.data;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
@@ -31,16 +33,18 @@ public class Model {
   private final String algorithm;
   private final String split;
   private final String predictionsDataset;
+  private final List<String> directives;
   private final Map<String, String> hyperparameters;
 
   protected Model(String name, String description, String algorithm, String split,
-                  @Nullable String predictionsDataset, Map<String, String> hyperparameters) {
+                  @Nullable String predictionsDataset, List<String> directives, Map<String, String> hyperparameters) {
     this.name = name;
     this.description = description;
     this.algorithm = algorithm;
     this.split = split;
     this.predictionsDataset = predictionsDataset;
-    this.hyperparameters = hyperparameters;
+    this.directives = Collections.unmodifiableList(directives);
+    this.hyperparameters = Collections.unmodifiableMap(hyperparameters);
   }
 
   public String getName() {
@@ -51,10 +55,16 @@ public class Model {
     return description == null ? "" : description;
   }
 
+  public List<String> getDirectives() {
+    return directives;
+  }
+
+  @Nullable
   public String getAlgorithm() {
     return algorithm;
   }
 
+  @Nullable
   public String getSplit() {
     return split;
   }
@@ -108,9 +118,11 @@ public class Model {
     protected String algorithm;
     protected String split;
     protected String predictionsDataset;
+    protected List<String> directives;
     protected Map<String, String> hyperparameters;
 
     protected Builder() {
+      directives = new ArrayList<>();
       hyperparameters = new HashMap<>();
     }
 
@@ -145,8 +157,14 @@ public class Model {
       return (T) this;
     }
 
+    public T setDirectives(List<String> directives) {
+      this.directives.clear();
+      this.directives.addAll(directives);
+      return (T) this;
+    }
+
     public Model build() {
-      return new Model(name, description, algorithm, split, predictionsDataset, hyperparameters);
+      return new Model(name, description, algorithm, split, predictionsDataset, directives, hyperparameters);
     }
   }
 

--- a/mmds-model/src/main/java/co/cask/mmds/data/ModelMeta.java
+++ b/mmds-model/src/main/java/co/cask/mmds/data/ModelMeta.java
@@ -24,11 +24,11 @@ public class ModelMeta extends Model {
   private final EvaluationMetrics evaluationMetrics;
 
   private ModelMeta(String id, String name, String description, String algorithm, String split,
-                    @Nullable String predictionsDataset, ModelStatus status,
+                    @Nullable String predictionsDataset, ModelStatus status, List<String> directives,
                     Map<String, String> hyperparameters, List<String> features, String outcome,
                     Set<String> categoricalFeatures, long createtime, long trainedtime,
                     long deploytime, EvaluationMetrics evaluationMetrics) {
-    super(name, description, algorithm, split, predictionsDataset, hyperparameters);
+    super(name, description, algorithm, split, predictionsDataset, directives, hyperparameters);
     this.id = id;
     this.status = status;
     this.outcome = outcome;
@@ -188,7 +188,7 @@ public class ModelMeta extends Model {
     }
 
     public ModelMeta build() {
-      return new ModelMeta(id, name, description, algorithm, split, predictionsDataset, status,
+      return new ModelMeta(id, name, description, algorithm, split, predictionsDataset, status, directives,
                            hyperparameters, features, outcome, categoricalFeatures, createtime,
                            trainedtime, deploytime, evaluationMetrics);
     }

--- a/mmds-model/src/main/java/co/cask/mmds/data/ModelStatus.java
+++ b/mmds-model/src/main/java/co/cask/mmds/data/ModelStatus.java
@@ -3,42 +3,46 @@ package co.cask.mmds.data;
 /**
  * Model status. The state transition diagram is:
  *
- *                                 |----------- assign split ------------------|
- *                                 |                                           |
- *                                 v       |-- split failed --> SPLIT_FAILED --|
- *   EMPTY -- assign split --> SPLITTING --|
- *                                 ^       |-- split succeeded --> DATA_READY -- assign modeler --> TRAINING
- *                                 |                                     |
- *                                 |-------------------------------------|
+ *       |----------------------- unassign split--------------------------------------------|
+ *       |                                                                      ^           |
+ *       |-- set directives --|                                                 |           |
+ *       |                    |           |----------- create split --------|   |           |
+ *       v       |------------|           |                                 |   |           |
+ *   PREPARING --|                        v       |-- split failed --> SPLIT_FAILED         |
+ *               |-- create split --> SPLITTING --|                                      |--|
+ *                                        ^       |-- split succeeded --> DATA_READY ----|
+ *                                        |                                 |            |-- train --> TRAINING
+ *                                        |---------------------------------|
  *
- *      |--------------- assign modeler ------------------|
- *      |                                                 |-- assign split --> SPLITTING.
- *      v       |-- training failed --> TRAINING_FAILED --|
+ *      |--------------- train -------------|
+ *      |                                   |
+ *      v       |-- training failed --> TRAINING_FAILED -- unassign split --> PREPARING
  *   TRAINING --|
  *              |-- training succeeded --> TRAINED -- deploy model --> DEPLOYED
  *
  *
  *
- * A model starts out in the EMPTY state. In the EMPTY state, it only has an id, name, and description.
+ * A model starts out in the PREPARING state. In the PREPARING state, directives can be modified.
  *
- * From the EMPTY state, it can be assigned a data split. If the split fails, the model moves to SPLIT_FAILED.
- * If the split succeeds, the model moves to DATA_READY.
+ * From the PREPARING state, a data split can be created.
+ * If the split succeeds, the model moves to DATA_READY. If the split fails, the model moves to SPLIT_FAILED.
  *
- * From the SPLIT_FAILED state, it can only be assigned a new data split, which moves it to SPLITTING.
+ * From the SPLIT_FAILED state, a new split can be created in case the failure was a transient failure. The split
+ * can also be unassigned, which brings the model back to the PREPARING state.
  *
- * From the DATA_READY state, it can be assigned a new data split, which moves it to SPLITTING. It can also be
- * assigned a modeler (algorithm and hyperparameters), which moves it to TRAINING.
+ * From the DATA_READY state, the split can be unassigned, which moves it to PREPARING. The model can also be
+ * trained, which moves it to TRAINING.
  *
  * From TRAINING, it moves to TRAINED if the model training succeeds.
  * If the training failed, it moves to TRAINING_FAILED.
  *
  * From the TRAINED state, it can be deployed, which moves it to DEPLOYED.
  *
- * From the TRAINING_FAILED state, it can be assigned a modeler, which moves it to the TRAINING state. It can also
- * be assigned a different split, which moves it back to the SPLITTING state.
+ * From the TRAINING_FAILED state, it can be trained again, which moves it to the TRAINING state. The split can also
+ * be unassigned, which moves it back to the PREPARING state.
  */
 public enum ModelStatus {
-  EMPTY("Empty"),
+  PREPARING("Preparing"),
   SPLITTING("Splitting"),
   SPLIT_FAILED("Split Failed"),
   DATA_READY("Data Ready"),

--- a/mmds-model/src/main/java/co/cask/mmds/proto/CreateModelRequest.java
+++ b/mmds-model/src/main/java/co/cask/mmds/proto/CreateModelRequest.java
@@ -1,15 +1,28 @@
 package co.cask.mmds.proto;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nullable;
+
 /**
  * Request to create a model
  */
 public class CreateModelRequest {
   private final String name;
   private final String description;
+  private final String split;
+  private final List<String> directives;
 
-  public CreateModelRequest(String name, String description) {
+  public CreateModelRequest(String name, String description, List<String> directives) {
+    this(name, description, directives, null);
+  }
+
+  public CreateModelRequest(String name, String description, List<String> directives, @Nullable String split) {
     this.name = name;
     this.description = description;
+    this.directives = Collections.unmodifiableList(directives);
+    this.split = split;
   }
 
   public String getName() {
@@ -18,6 +31,14 @@ public class CreateModelRequest {
 
   public String getDescription() {
     return description;
+  }
+
+  public String getSplit() {
+    return split;
+  }
+
+  public List<String> getDirectives() {
+    return directives == null ? new ArrayList<>() : directives;
   }
 
   /**
@@ -29,6 +50,9 @@ public class CreateModelRequest {
   public void validate() {
     if (name == null || name.isEmpty()) {
       throw new BadRequestException("Must specify a name");
+    }
+    if (split != null && directives != null) {
+      throw new BadRequestException("Cannot specify both directives and a split.");
     }
   }
 }

--- a/mmds-model/src/main/java/co/cask/mmds/proto/DirectivesRequest.java
+++ b/mmds-model/src/main/java/co/cask/mmds/proto/DirectivesRequest.java
@@ -1,0 +1,29 @@
+package co.cask.mmds.proto;
+
+import java.util.List;
+
+/**
+ * Request to set model directives.
+ */
+public class DirectivesRequest {
+  private final List<String> directives;
+
+  public DirectivesRequest(List<String> directives) {
+    this.directives = directives;
+  }
+
+  public List<String> getDirectives() {
+    return directives;
+  }
+
+  /**
+   * validate the request
+   *
+   * @throws BadRequestException if the request is invalid
+   */
+  public void validate() {
+    if (directives == null) {
+      throw new BadRequestException("Directives must be specified.");
+    }
+  }
+}

--- a/mmds-plugins/src/main/java/co/cask/mmds/plugin/MLPredictor.java
+++ b/mmds-plugins/src/main/java/co/cask/mmds/plugin/MLPredictor.java
@@ -6,7 +6,7 @@ import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.lib.FileSet;
-import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.api.dataset.lib.IndexedTable;
 import co.cask.cdap.api.spark.sql.DataFrames;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
@@ -86,7 +86,7 @@ public class MLPredictor extends SparkCompute<StructuredRecord, StructuredRecord
     predictionType = predictionSchema.getType();
 
     // verify that the features used to train the model are present in the input.
-    Table modelTable = context.getDataset(conf.getModelMetaDataset());
+    IndexedTable modelTable = context.getDataset(conf.getModelMetaDataset());
     ModelTable modelMetaTable = new ModelTable(modelTable);
     ModelKey key = new ModelKey(conf.getExperimentID(), conf.getModelID());
     ModelMeta meta = modelMetaTable.get(key);

--- a/mmds-plugins/src/test/java/co/cask/mmds/PipelineTest.java
+++ b/mmds-plugins/src/test/java/co/cask/mmds/PipelineTest.java
@@ -72,6 +72,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import edu.emory.mathcs.backport.java.util.Collections;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -207,7 +208,8 @@ public class PipelineTest extends HydratorTestBase {
       .setDirectives(directives)
       .build();
 
-    CreateModelRequest createModelRequest = new CreateModelRequest("dtree", "decision tree classifier");
+    CreateModelRequest createModelRequest = new CreateModelRequest("dtree", "decision tree classifier",
+                                                                   Collections.emptyList());
     String modelId = createModel(experiment.getName(), createModelRequest);
 
     DataSplitStats splitStats = addSplit(experiment.getName(), dataSplit, 180);
@@ -315,7 +317,8 @@ public class PipelineTest extends HydratorTestBase {
       .setDirectives(directives)
       .build();
 
-    CreateModelRequest createModelRequest = new CreateModelRequest("dtree", "decision tree regression");
+    CreateModelRequest createModelRequest = new CreateModelRequest("dtree", "decision tree regression",
+                                                                   Collections.emptyList());
     String modelId = createModel(experiment.getName(), createModelRequest);
 
     DataSplitStats splitStats = addSplit(experiment.getName(), dataSplit, 180);


### PR DESCRIPTION
Instead of directly assigning a split to a model, adding directives
directly to the model object. A split can then be created by requesting
a split on the model.