### PR TITLE
Update netty-http version to 1.0.0, consistent with what CDAP 5.0 uses.

### DIFF
--- a/mmds-app/pom.xml
+++ b/mmds-app/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>co.cask.http</groupId>
       <artifactId>netty-http</artifactId>
-      <version>0.16.0</version>
+      <version>${netty.http.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cdap.version>5.0.0-SNAPSHOT</cdap.version>
+    <netty.http.version>1.0.0</netty.http.version>
     <gson.version>2.7</gson.version>
     <guava.version>13.0.1</guava.version>
     <hadoop.version>2.3.0</hadoop.version>


### PR DESCRIPTION
Update netty-http version to 1.0.0, consistent with what CDAP 5.0 uses.
CDAP 5.0 uses netty-http 1.0.0: https://github.com/caskdata/cdap/blob/develop/pom.xml#L137