### PR TITLE
CDAP-14100 add start and end times for splits

### DIFF
--- a/mmds-model/src/main/java/co/cask/mmds/data/DataSplitStats.java
+++ b/mmds-model/src/main/java/co/cask/mmds/data/DataSplitStats.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
@@ -37,10 +38,12 @@ public class DataSplitStats extends DataSplit {
   private final SplitStatus status;
   private final List<ColumnSplitStats> stats;
   private final Set<String> models;
+  private final long start;
+  private final long end;
 
   public DataSplitStats(String id, String description, String type, Map<String, String> params, List<String> directives,
                         Schema schema, String trainingPath, String testPath, SplitStatus status,
-                        List<ColumnSplitStats> stats, Set<String> models) {
+                        List<ColumnSplitStats> stats, Set<String> models, long start, long end) {
     super(description, type, params, directives, schema);
     this.id = id;
     this.trainingPath = trainingPath;
@@ -48,6 +51,8 @@ public class DataSplitStats extends DataSplit {
     this.status = status;
     this.stats = stats;
     this.models = Collections.unmodifiableSet(models);
+    this.start = start;
+    this.end = end;
   }
 
   public String getId() {
@@ -76,6 +81,14 @@ public class DataSplitStats extends DataSplit {
     return models;
   }
 
+  public long getStart() {
+    return start;
+  }
+
+  public long getEnd() {
+    return end;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -87,20 +100,20 @@ public class DataSplitStats extends DataSplit {
     if (!super.equals(o)) {
       return false;
     }
-
     DataSplitStats that = (DataSplitStats) o;
-
-    return Objects.equals(id, that.id) &&
+    return start == that.start &&
+      end == that.end &&
+      Objects.equals(id, that.id) &&
       Objects.equals(trainingPath, that.trainingPath) &&
       Objects.equals(testPath, that.testPath) &&
-      Objects.equals(status, that.status) &&
+      status == that.status &&
       Objects.equals(stats, that.stats) &&
       Objects.equals(models, that.models);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, trainingPath, testPath, status, stats, models);
+    return Objects.hash(super.hashCode(), id, trainingPath, testPath, status, stats, models, start, end);
   }
 
   /**
@@ -120,11 +133,15 @@ public class DataSplitStats extends DataSplit {
     private SplitStatus status;
     private List<ColumnSplitStats> stats;
     private Set<String> models;
+    private long start;
+    private long end;
 
     public Builder(String id) {
       this.id = id;
       models = new HashSet<>();
       stats = new ArrayList<>();
+      start = -1L;
+      end = -1L;
     }
 
     public Builder setTrainingPath(String trainingPath) {
@@ -154,9 +171,19 @@ public class DataSplitStats extends DataSplit {
       return this;
     }
 
+    public Builder setStartTime(long startMillis) {
+      this.start = startMillis;
+      return this;
+    }
+
+    public Builder setEndTime(long endMillis) {
+      this.end = endMillis;
+      return this;
+    }
+
     public DataSplitStats build() {
       DataSplitStats splitStats = new DataSplitStats(id, description, type, params, directives, schema,
-                                                     trainingPath, testPath, status, stats, models);
+                                                     trainingPath, testPath, status, stats, models, start, end);
       splitStats.validate();
       return splitStats;
     }
@@ -168,9 +195,11 @@ public class DataSplitStats extends DataSplit {
       "id='" + id + '\'' +
       ", trainingPath='" + trainingPath + '\'' +
       ", testPath='" + testPath + '\'' +
-      ", status='" + status + '\'' +
+      ", status=" + status +
       ", stats=" + stats +
       ", models=" + models +
-      "} " + super.toString();
+      ", start=" + start +
+      ", end=" + end +
+      '}';
   }
 }

--- a/mmds-model/src/main/java/co/cask/mmds/data/ModelMeta.java
+++ b/mmds-model/src/main/java/co/cask/mmds/data/ModelMeta.java
@@ -31,6 +31,7 @@ import javax.annotation.Nullable;
 public class ModelMeta extends Model {
   private final String id;
   private final long createtime;
+  private final long trainingtime;
   private final long trainedtime;
   private final long deploytime;
   private final ModelStatus status;
@@ -42,8 +43,8 @@ public class ModelMeta extends Model {
   private ModelMeta(String id, String name, String description, String algorithm, String split,
                     @Nullable String predictionsDataset, ModelStatus status, List<String> directives,
                     Map<String, String> hyperparameters, List<String> features, String outcome,
-                    Set<String> categoricalFeatures, long createtime, long trainedtime,
-                    long deploytime, EvaluationMetrics evaluationMetrics) {
+                    Set<String> categoricalFeatures, long createtime, long trainingtime, long trainedtime,
+                    Long deploytime, EvaluationMetrics evaluationMetrics) {
     super(name, description, algorithm, split, predictionsDataset, directives, hyperparameters);
     this.id = id;
     this.status = status;
@@ -51,6 +52,7 @@ public class ModelMeta extends Model {
     this.features = Collections.unmodifiableList(features);
     this.categoricalFeatures = Collections.unmodifiableSet(categoricalFeatures);
     this.createtime = createtime;
+    this.trainingtime = trainingtime;
     this.trainedtime = trainedtime;
     this.deploytime = deploytime;
     this.evaluationMetrics = evaluationMetrics;
@@ -70,6 +72,10 @@ public class ModelMeta extends Model {
 
   public long getCreatetime() {
     return createtime;
+  }
+
+  public long getTrainingtime() {
+    return trainingtime;
   }
 
   public long getTrainedtime() {
@@ -129,6 +135,7 @@ public class ModelMeta extends Model {
   public static Builder builder(ModelMeta meta) {
     return new Builder(meta.id)
       .setCreateTime(meta.createtime)
+      .setTrainingTime(meta.trainingtime)
       .setTrainedTime(meta.trainedtime)
       .setDeployTime(meta.deploytime)
       .setOutcome(meta.outcome)
@@ -144,6 +151,7 @@ public class ModelMeta extends Model {
   public static class Builder extends Model.Builder<Builder> {
     private final String id;
     private long createtime;
+    private long trainingtime;
     private long trainedtime;
     private long deploytime;
     private String outcome;
@@ -156,6 +164,7 @@ public class ModelMeta extends Model {
       this.id = id;
       this.features = new ArrayList<>();
       this.categoricalFeatures = new HashSet<>();
+      this.trainingtime = -1L;
       this.trainedtime = -1L;
       this.deploytime = -1L;
       this.evaluationMetrics = new EvaluationMetrics(null, null, null, null, null, null, null);
@@ -168,6 +177,11 @@ public class ModelMeta extends Model {
 
     public Builder setDeployTime(long deployTime) {
       this.deploytime = deployTime;
+      return this;
+    }
+
+    public Builder setTrainingTime(long trainingTime) {
+      this.trainingtime = trainingTime;
       return this;
     }
 
@@ -206,7 +220,7 @@ public class ModelMeta extends Model {
     public ModelMeta build() {
       return new ModelMeta(id, name, description, algorithm, split, predictionsDataset, status, directives,
                            hyperparameters, features, outcome, categoricalFeatures, createtime,
-                           trainedtime, deploytime, evaluationMetrics);
+                           trainingtime, trainedtime, deploytime, evaluationMetrics);
     }
   }
 }

--- a/mmds-plugins/src/test/java/co/cask/mmds/PipelineTest.java
+++ b/mmds-plugins/src/test/java/co/cask/mmds/PipelineTest.java
@@ -470,7 +470,7 @@ public class PipelineTest extends HydratorTestBase {
     DataSetManager<PartitionedFileSet> splitsDatasetManager = getDataset(Constants.Dataset.SPLITS);
     PartitionedFileSet splitsDataset = splitsDatasetManager.get();
     DataSplitTable dataSplitTable = new DataSplitTable(splitsDataset);
-    String splitId = dataSplitTable.addSplit(experiment, split);
+    String splitId = dataSplitTable.addSplit(experiment, split, System.currentTimeMillis());
     splitsDatasetManager.flush();
 
     Map<String, String> properties = ImmutableMap.of("experimentId", experiment, "splitId", splitId);


### PR DESCRIPTION
Added a 'start' and 'end' timestamp for data splits. They default
to -1 if they are not applicable, or if it is a split from a
previous version.

Also added a 'trainingtime' timestamp to models that record when
the training started.