### PR TITLE
[CDAP-20224] Remove explore references from mmds

### DIFF
--- a/mmds-app/src/main/java/io/cdap/mmds/manager/WranglerContext.java
+++ b/mmds-app/src/main/java/io/cdap/mmds/manager/WranglerContext.java
@@ -22,6 +22,7 @@ import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.metadata.Metadata;
 import io.cdap.cdap.api.metadata.MetadataEntity;
 import io.cdap.cdap.api.metadata.MetadataScope;
+import io.cdap.cdap.api.metrics.Metrics;
 import io.cdap.cdap.api.plugin.PluginContext;
 import io.cdap.cdap.api.plugin.PluginProperties;
 import io.cdap.cdap.etl.api.Arguments;
@@ -90,6 +91,11 @@ public class WranglerContext implements TransformContext {
       }
 
       @Override
+      public Metrics child(Map<String, String> map) {
+        return null;
+      }
+
+      @Override
       public void pipelineCount(String s, int i) {
         // no-op
       }
@@ -97,6 +103,11 @@ public class WranglerContext implements TransformContext {
       @Override
       public void pipelineGauge(String s, long l) {
         // no-op
+      }
+
+      @Override
+      public Map<String, String> getTags() {
+        return Collections.emptyMap();
       }
     };
   }

--- a/mmds-app/src/test/java/io/cdap/mmds/StoreTest.java
+++ b/mmds-app/src/test/java/io/cdap/mmds/StoreTest.java
@@ -23,8 +23,7 @@ import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.lib.IndexedTable;
 import io.cdap.cdap.api.dataset.lib.PartitionedFileSet;
 import io.cdap.cdap.test.DataSetManager;
-import io.cdap.cdap.test.TestBaseWithSpark2;
-import io.cdap.cdap.test.TestConfiguration;
+import io.cdap.cdap.test.TestBase;
 import io.cdap.mmds.data.DataSplit;
 import io.cdap.mmds.data.DataSplitInfo;
 import io.cdap.mmds.data.DataSplitStats;
@@ -45,23 +44,18 @@ import io.cdap.mmds.manager.ModelPrepApp;
 import io.cdap.mmds.proto.ConflictException;
 import io.cdap.mmds.proto.CreateModelRequest;
 import io.cdap.mmds.proto.TrainModelRequest;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Unit tests.
  */
-public class StoreTest extends TestBaseWithSpark2 {
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+public class StoreTest extends TestBase {
 
   private DataSetManager<IndexedTable> experimentsManager;
   private ExperimentMetaTable experimentsTable;

--- a/mmds-model/src/main/java/io/cdap/mmds/data/DataSplitTable.java
+++ b/mmds-model/src/main/java/io/cdap/mmds/data/DataSplitTable.java
@@ -66,7 +66,6 @@ public class DataSplitTable {
   private static final String END = "end";
   public static final DatasetProperties DATASET_PROPERTIES = PartitionedFileSetProperties.builder()
     .setPartitioning(Partitioning.builder().addStringField(EXPERIMENT).addStringField(SPLIT).build())
-    .setEnableExploreOnCreate(false)
     .setDescription("Contains data splits used to train models")
     .build();
   private final PartitionedFileSet splits;

--- a/mmds-model/src/main/java/io/cdap/mmds/modeler/train/ModelOutputWriter.java
+++ b/mmds-model/src/main/java/io/cdap/mmds/modeler/train/ModelOutputWriter.java
@@ -27,19 +27,17 @@ import io.cdap.cdap.api.dataset.lib.PartitionedFileSet;
 import io.cdap.cdap.api.dataset.lib.PartitionedFileSetProperties;
 import io.cdap.cdap.api.dataset.lib.Partitioning;
 import io.cdap.mmds.Constants;
-import io.cdap.mmds.Schemas;
 import io.cdap.mmds.api.AlgorithmType;
 import io.cdap.mmds.data.ModelKey;
-import org.apache.spark.sql.SaveMode;
-import org.apache.twill.filesystem.Location;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
+import org.apache.spark.sql.SaveMode;
+import org.apache.twill.filesystem.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Writes Model components.
@@ -90,10 +88,6 @@ public class ModelOutputWriter {
           Schema.recordOf(modelOutput.getSchema().getRecordName() + ".prediction", predictionFields);
         DatasetProperties datasetProperties = PartitionedFileSetProperties.builder()
           .setPartitioning(Partitioning.builder().addStringField("experiment").addStringField("model").build())
-          .setEnableExploreOnCreate(true)
-          .setExploreFormat("text")
-          .setExploreFormatProperty("delimiter", ",")
-          .setExploreSchema(Schemas.toHiveSchema(predictionSchema))
           .build();
 
         admin.createDataset(predictionsDataset, PartitionedFileSet.class.getName(), datasetProperties);

--- a/mmds-plugins/src/test/java/io/cdap/mmds/PipelineTest.java
+++ b/mmds-plugins/src/test/java/io/cdap/mmds/PipelineTest.java
@@ -72,14 +72,6 @@ import io.cdap.mmds.proto.CreateModelRequest;
 import io.cdap.mmds.proto.TrainModelRequest;
 import io.cdap.mmds.stats.CategoricalHisto;
 import io.cdap.wrangler.Wrangler;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -91,6 +83,13 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
 
 /**
  * Unit tests for our plugins.
@@ -103,8 +102,8 @@ public class PipelineTest extends HydratorTestBase {
     .create();
   private static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("data-pipeline", "1.0.0");
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false,
-                                                                       "app.program.spark.compat", "spark2_2.11");
+  public static final TestConfiguration CONFIG =
+      new TestConfiguration("app.program.spark.compat", "spark2_2.11");
   private static SparkManager sparkManager;
   private static URL serviceURL;
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.1.1</cdap.version>
+    <cdap.version>6.9.0-SNAPSHOT</cdap.version>
     <netty.http.version>1.3.0</netty.http.version>
     <gson.version>2.7</gson.version>
     <guava.version>13.0.1</guava.version>


### PR DESCRIPTION
- As part of cdapio/cdap/pull/14802, the module `cdap-explore` and its references and occurrences are removed from CDAP repository.
- Similar references in `cdap-solutions` need to be removed.
[JIRA](https://cdap.atlassian.net/browse/CDAP-20224)